### PR TITLE
Start of a prototype for string-based, very strict, type dispatching

### DIFF
--- a/prototype_backend.py
+++ b/prototype_backend.py
@@ -1,23 +1,45 @@
+import textwrap
+
 # This should be fetched via an entry-point, but lets do it here for now!
 
 # This type of dictionary could be all there is to a backend for now.
 # Of course... the backend will need machinery to conveniently build it.
+# The backend-info dict, after build needs to live in a minimal/cheap to
+# import module.
 backend_info = {
     "name": "my_backend",
-    "types": "numpy:matrix",
-    "symbol_mapping": {
-        "prototype_module:func1": {
-            "impl_symbol": "prototype_backend:my_func1",
-            "doc_blurp": "This text added by `my_backend`!",
-        }
-    }
+    "types": ["numpy:matrix"],
+    "symbol_mapping": {},
 }
 
 
 from spatch import WillNotHandle
 
+
+def implements(func):
+    """Helper decorator.  Since/if we name our modules identically to the
+    main module, we can just do a simple replace the module and be done.
+    """
+    mod = func.__module__
+    # TODO: May want to make sure to replace the start exactly, but OK...
+    orig_mod = mod.replace("prototype_backend", "prototype_module")
+    name = func.__qualname__
+
+    backend_info["symbol_mapping"][f"{orig_mod}:{name}"] = {
+        "impl_symbol": f"{mod}:{name}",
+        "doc_blurp": textwrap.dedent(func.__doc__).strip("\n"),
+    }
+
+    # We don't actually change the function, just keep track of it.
+    return func
+
+
 # TODO/NOTE: This function would of course be in a different module!
-def my_func1(arg, optional=None, parameter="param"):
+@implements
+def func1(arg, optional=None, parameter="param"):
+    """
+    This text is added by `my_backend`!
+    """
     if parameter != "param":
         return WillNotHandle("Don't know how to do param.")
     return "my_backend called"

--- a/prototype_backend.py
+++ b/prototype_backend.py
@@ -1,0 +1,23 @@
+# This should be fetched via an entry-point, but lets do it here for now!
+
+# This type of dictionary could be all there is to a backend for now.
+# Of course... the backend will need machinery to conveniently build it.
+backend_info = {
+    "name": "my_backend",
+    "types": "numpy:matrix",
+    "symbol_mapping": {
+        "prototype_module:func1": {
+            "impl_symbol": "prototype_backend:my_func1",
+            "doc_blurp": "This text added by `my_backend`!",
+        }
+    }
+}
+
+
+from spatch import WillNotHandle
+
+# TODO/NOTE: This function would of course be in a different module!
+def my_func1(arg, optional=None, parameter="param"):
+    if parameter != "param":
+        return WillNotHandle("Don't know how to do param.")
+    return "my_backend called"

--- a/prototype_example.py
+++ b/prototype_example.py
@@ -10,5 +10,5 @@ print("\n\nTrivial call examples:\n")
 print(prototype_module.func1([1, 2, 3]))
 print(prototype_module.func1(np.matrix([1, 2, 3])))
 
-print("\nNobody can handle this")
+print("\nNobody can handle this example:")
 prototype_module.func1(np.matrix([1, 2, 3]), parameter="uhoh!")

--- a/prototype_example.py
+++ b/prototype_example.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+import prototype_module
+
+
+print(prototype_module.func1.__doc__)
+
+print("\n\nTrivial call examples:\n")
+
+print(prototype_module.func1([1, 2, 3]))
+print(prototype_module.func1(np.matrix([1, 2, 3])))
+
+print("\nNobody can handle this")
+prototype_module.func1(np.matrix([1, 2, 3]), parameter="uhoh!")

--- a/prototype_module.py
+++ b/prototype_module.py
@@ -1,12 +1,7 @@
 # This is a silly module that might be used by a user.
 from spatch import Backend, BackendSystem, WillNotHandle
 
-_backend_sys = BackendSystem()
-
-# This part would have to happen through entry-points:
-from prototype_backend import backend_info
-
-_backend_sys.backend_from_dict(backend_info)
+_backend_sys = BackendSystem("prototype_modules_backends")
 
 
 @_backend_sys.dispatchable("arg", "optional")

--- a/prototype_module.py
+++ b/prototype_module.py
@@ -1,5 +1,5 @@
 # This is a silly module that might be used by a user.
-from spatch import Backend, BackendSystem, WillNotHandle
+from spatch import BackendSystem, WillNotHandle
 
 _backend_sys = BackendSystem("prototype_modules_backends")
 

--- a/prototype_module.py
+++ b/prototype_module.py
@@ -1,0 +1,27 @@
+# This is a silly module that might be used by a user.
+from spatch import Backend, BackendSystem, WillNotHandle
+
+_backend_sys = BackendSystem()
+
+# This part would have to happen through entry-points:
+from prototype_backend import backend_info
+
+_backend_sys.backend_from_dict(backend_info)
+
+
+@_backend_sys.dispatchable("arg", "optional")
+def func1(arg, /, optional=None, parameter="param"):
+    """
+    This is my function
+
+    Parameters
+    ----------
+    ...
+
+    """
+    if parameter != "param":
+        # I suppose even the fallback/default can refuse to handle it?
+        return WillNotHandle("Don't know how to do param.")
+
+    return "default implementation called!"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ authors = [
 ]
 version = "0.0.0"
 description = "Coming soon"
+
+
+[project.entry-points.prototype_modules_backends]
+my_backend = 'prototype_backend:backend_info'

--- a/spatch/__init__.py
+++ b/spatch/__init__.py
@@ -110,9 +110,11 @@ class BackendSystem:
                 map these correctly).
         """
         def wrap_callable(func):
-            disp = Dispatchable(self, func, relevant_args)
+            # Overwrite original module (we use it later, could also pass it)
             if module is not None:
-                disp.__module__ = module
+                func.__module__ = module
+
+            disp = Dispatchable(self, func, relevant_args)
 
             return disp
 
@@ -122,7 +124,7 @@ class Dispatchable:
     """Dispatchable function object
 
     """
-    def __init__(self, backend_system, func, relevant_args):
+    def __init__(self, backend_system, func, relevant_args, ident=None):
         self._backend_system = backend_system
         self._sig = inspect.signature(func)
         self._relevant_args = relevant_args

--- a/spatch/__init__.py
+++ b/spatch/__init__.py
@@ -1,0 +1,212 @@
+import inspect
+import functools
+import importlib
+import textwrap
+
+
+def get_identifier(obj):
+    """Helper to get any objects identifier.  Is there an exiting short-hand?
+    """
+    return f"{obj.__module__}:{obj.__qualname__}"
+
+
+def from_identifier(ident):
+    module, qualname = ident.split(":")
+    obj = importlib.import_module(module)
+    for name in qualname.split("."):
+        obj = getattr(obj, name)
+
+    return obj
+
+
+class WillNotHandle:
+    """Class to return when an implementation does not want to handle
+    args/kwargs.
+    """
+    def __init__(self, info="<unknown reason>"):
+        self.info = info
+
+
+class Backend: 
+    @classmethod
+    def from_info_dict(cls, info):
+        return cls.from_mapping_and_types(info["name"], info["types"], info["symbol_mapping"])
+
+    @classmethod
+    def from_mapping_and_types(cls, name, types, symbol_mapping):
+        """
+        Create a new backend.
+        """
+        self = cls()
+        self.name = name
+        self.type_names = types
+        self.symbol_mapping = symbol_mapping
+        return self
+
+    def match_types(self, types):
+        """See if this backend matches the types, we do this by name.
+
+        Of course, we could use more complicated ways in the future.
+        E.g. one thing is that we can have to kind of types:
+        1. Types that must match (at least once).
+        2. Types that are understood (we do not break for them).
+
+        Returns
+        -------
+        matches : boolean
+            Whether or not the types matches.
+        unknown_types : sequence of types
+            A sequence of types the backend did not match/know.
+            This may be a way to e.g. deal with scalars, that we assume
+            all backends can convert, but creating an extensive list may
+            not be desireable?
+        """
+        matches = False
+        unknown_types = []
+        for t in types:
+            ident = f"{t.__module__}:{t.__qualname__}"
+
+            if ident in self.type_names:
+                matches = True
+                unknown_types.append(t)
+
+        return matches, unknown_types
+
+
+class BackendSystem:
+    def __init__(self):
+        # TODO: We could define types of the fallback here, or known "scalar"
+        #       (i.e. unimportant types).
+        #       In a sense, the fallback should maybe itself just be a normal
+        #       backend, except we always try it if all else fails...
+        self.backends = {}
+
+    def backend_from_dict(self, info_dict):
+        new_backend = Backend.from_info_dict(info_dict)
+        if new_backend.name in self.backends:
+            raise ValueError(f"Backend of name '{new_backend.name}' already exists!")
+        self.backends[new_backend.name] = new_backend
+
+    def dispatchable(self, *relevant_args):
+        """
+        Decorate a Python function with information on how to extract
+        the "relevant" arguments, i.e. arguments we wish to dispatch for.
+
+        Parameters
+        ----------
+        *relevant_args : The names of parameters to extract (we use inspect to
+                map these correctly).
+        """
+        def wrap_callable(func):
+            return Dispatchable(self, func, relevant_args)
+
+        return wrap_callable
+
+class Dispatchable:
+    """Dispatchable function object
+
+    """
+    def __init__(self, backend_system, func, relevant_args):
+        self._backend_system = backend_system
+        self._sig = inspect.signature(func)
+        self._relevant_args = relevant_args
+        self._default_impl = func
+        # Keep a list of implementations for this backend
+        self._implementations = []
+
+        ident = get_identifier(func)
+
+        functools.update_wrapper(self, func)
+
+        new_doc = []
+        for backend in backend_system.backends.values():
+            info = backend.symbol_mapping.get(ident, None)
+            self._implementations.append((backend, info["impl_symbol"]))
+            if info is None:
+                continue
+
+            impl_symbol = info["impl_symbol"]
+            doc_blurp = info.get("doc_blurp", "No backend documentation available.")
+            new_doc.append(f"backend.name :\n" + textwrap.indent(doc_blurp, "    "))
+
+        if not new_doc:
+            new_doc = "No backends found for this function."
+
+        new_doc = "\n\n".join(new_doc)
+        new_doc = "\n\nBackends\n--------\n" + new_doc
+
+        # Just dedent, so it makes sense to append (should be fine):
+        self.__doc__ = textwrap.dedent(self.__doc__) + new_doc
+
+    def __get__(self, ):
+        raise NotImplementedError(
+            "Need to implement this eventually to act like functions.")
+
+    @property
+    def _backends(self):
+        # Extract the backends:
+        return [impl[0] for impl in self._implementations]
+
+    def _find_matching_backends(self, relevant_types):
+        """Find all matching backends.
+        """
+        matching = []
+        unknown_types = relevant_types
+        for backend, impl in self._implementations:
+            matches, unknown_types_backend = backend.match_types(relevant_types)
+            unknown_types = unknown_types.union(unknown_types_backend)
+
+            if matches:
+                matching.append((backend, impl, unknown_types))
+
+        match_with_unknown = []
+        for backend, impl, unknown_types_backend in matching:
+            # If the types the backend didn't know are also not known by
+            # any other backend, we just ignore them
+            if unknown_types_backend.issubset(unknown_types):
+                match_with_unknown.append((backend, impl))
+
+        return match_with_unknown
+
+    def __call__(self, *args, **kwargs):
+        partial = self._sig.bind_partial(*args, **kwargs)
+
+        relevant_types = set()
+        for arg in self._relevant_args:
+            val = partial.arguments.get(arg, None)
+            if val is not None:
+                relevant_types.add(type(val))
+
+        matching_impls = self._find_matching_backends(relevant_types)
+
+        # TODO: When more than one backend matches, we could:
+        # 1. Ensure e.g. an alphabetic order early on during registration.
+        # 2. Inspect types, to see if one backend is clearly more specific
+        #    than another one.
+        reasons = []
+        for backend, impl in matching_impls + [(None, self._default_impl)]:
+            # Call the backend:
+            if isinstance(impl, str):
+                # TODO: Should update the impl we store, to do this only once!
+                impl = from_identifier(impl)
+
+            result = impl(*args, **kwargs)
+            if isinstance(result, WillNotHandle):
+                # The backend indicated it cannot/does not want to handle
+                # this.
+                reasons.append((backend, result))
+            else:
+                return result
+
+        if len(reasons) == 1:
+            backends = self._backends
+            msg = (f"No backend matched out of {backends} and the default "
+                   f"did not work because of: {reasons[0][1].info}")
+        else:
+            msg = f"Of the available backends, the following were tried but failed:"
+            for backend, reason in reasons:
+                name = "default" if backend is None else backend.name
+                msg += f"\n - {name}: {reason}"
+
+        raise TypeError(msg)
+

--- a/spatch/__init__.py
+++ b/spatch/__init__.py
@@ -64,7 +64,7 @@ class Backend:
         matches = False
         unknown_types = []
         for t in types:
-            ident = f"{t.__module__}:{t.__qualname__}"
+            ident = get_identifier(t)
 
             if ident in self.type_names:
                 matches = True

--- a/spatch/__init__.py
+++ b/spatch/__init__.py
@@ -99,7 +99,7 @@ class BackendSystem:
             return
         self.backends[new_backend.name] = new_backend
 
-    def dispatchable(self, *relevant_args):
+    def dispatchable(self, *relevant_args, module=None):
         """
         Decorate a Python function with information on how to extract
         the "relevant" arguments, i.e. arguments we wish to dispatch for.
@@ -110,7 +110,9 @@ class BackendSystem:
                 map these correctly).
         """
         def wrap_callable(func):
-            return Dispatchable(self, func, relevant_args)
+            disp = Dispatchable(self, func, relevant_args)
+            if module is not None:
+                disp.__module__ = module
 
         return wrap_callable
 

--- a/spatch/__init__.py
+++ b/spatch/__init__.py
@@ -114,6 +114,8 @@ class BackendSystem:
             if module is not None:
                 disp.__module__ = module
 
+            return disp
+
         return wrap_callable
 
 class Dispatchable:


### PR DESCRIPTION
This is an early (and very dirty) start, in case it is useful to get going.  (Ping @eriknw)

The "example" is just the `prototype_*` modules, with the `_example` one being executable.  I did not look into the entry-points, and of course this is all very raw:
1. We can make the way we dispatch on types much smarter:
   * For speed
   * For backend order (potentially), this code doesn't even try to address that.
   * I had discussed with Eric, having types we expect/need to match, and types we understand can make sense.  E.g. `cucim` may want to only kick in for cupy arrays, but _understand_ `numpy` arrays.  A better example maybe a `dask.array` backend which can understand cupy/numpy, but will never be picked for those.
2. This is just string based, that can be relaxed of course.
3. I added a `WillNotHandle()` return class to pass out information for rejection, since I liked that idea:
   * (We cannot "force" right now, in this way, I suspect that is OK for now.)
4. I solved the parameter selection with strings + `inspect`, which I really like for simplicity.
   We need the signature fetching for it, but otherwise we can always optimize it.


Anyway, sharing in the hoping it might help.  But please feel free to ignore if you have another start and are pushing forward there!