### PR TITLE
PoC,WIP: Second take of a featured dispatching tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ authors = [
 ]
 version = "0.0.0"
 description = "Coming soon"
+
+[project.entry-points._spatch_example_backends]
+my_backend = 'spatch._spatch_example.entry_point'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ version = "0.0.0"
 description = "Coming soon"
 
 [project.entry-points._spatch_example_backends]
-my_backend = 'spatch._spatch_example.entry_point'
+example_backend1 = 'spatch._spatch_example.entry_point'
+example_backend2 = 'spatch._spatch_example.entry_point2'

--- a/spatch/_spatch_example/backend.py
+++ b/spatch/_spatch_example/backend.py
@@ -10,8 +10,16 @@ def implements(ident, should_run=None):
     return decorator
 
 
+# for backend 1
 @implements("spatch._spatch_example.library:divide", should_run=lambda x, y: True)
 def divide(x, y):
+    print("hello from backend 1")
     return x / y
 
+
+# For backend 2
+@implements("spatch._spatch_example.library:divide", should_run=lambda x, y: True)
+def divide2(x, y):
+    print("hello from backend 2")
+    return x / y
 

--- a/spatch/_spatch_example/backend.py
+++ b/spatch/_spatch_example/backend.py
@@ -1,0 +1,17 @@
+
+
+def implements(ident, should_run=None):
+    """Attach should_run to the function.  In the future this would
+    also be used to generate the function dict for the entry point.
+    """
+    def decorator(func):
+        func._should_run = should_run
+        return func
+    return decorator
+
+
+@implements("spatch._spatch_example.library:divide", should_run=lambda x, y: True)
+def divide(x, y):
+    return x / y
+
+

--- a/spatch/_spatch_example/entry_point.py
+++ b/spatch/_spatch_example/entry_point.py
@@ -8,7 +8,8 @@ functions = {
     "spatch._spatch_example.library:divide": {
         "function": "spatch._spatch_example.backend:divide",
         "should_run": "spatch._spatch_example.backend:divide._should_run",
-        "additional_docs": "This is a test backend."
+        "additional_docs": "This is a test backend.",
+        "uses_info": True,
     }
 }
 

--- a/spatch/_spatch_example/entry_point.py
+++ b/spatch/_spatch_example/entry_point.py
@@ -1,0 +1,13 @@
+
+name = "backend1"
+primary_types = ["builtins:float", "builtins:complex"]
+secondary_types = ["builtins:int"]
+
+
+functions = {
+    "spatch._spatch_example.library:divide": {
+        "function": "spatch._spatch_example.backend:divide",
+        "should_run": "spatch._spatch_example.backend:divide._should_run",
+        "additional_docs": "This is a test backend."
+    }
+}

--- a/spatch/_spatch_example/entry_point.py
+++ b/spatch/_spatch_example/entry_point.py
@@ -1,6 +1,6 @@
 
 name = "backend1"    
-primary_types = ["builtins:float", "builtins:complex"]
+primary_types = ["builtins:float"]
 secondary_types = ["builtins:int"]
 
 
@@ -11,3 +11,7 @@ functions = {
         "additional_docs": "This is a test backend."
     }
 }
+
+# TODO: The documentation has to tell people not to create circles.
+# and that includes with the types?!
+# prioritize_over_backends = ["numpy"]

--- a/spatch/_spatch_example/entry_point.py
+++ b/spatch/_spatch_example/entry_point.py
@@ -1,5 +1,5 @@
 
-name = "backend1"
+name = "backend1"    
 primary_types = ["builtins:float", "builtins:complex"]
 secondary_types = ["builtins:int"]
 

--- a/spatch/_spatch_example/entry_point2.py
+++ b/spatch/_spatch_example/entry_point2.py
@@ -1,0 +1,13 @@
+
+name = "backend2"    
+primary_types = ["builtins:float", "builtins:complex"]
+secondary_types = ["builtins:int"]
+
+
+functions = {
+    "spatch._spatch_example.library:divide": {
+        "function": "spatch._spatch_example.backend:divide2",
+        "should_run": "spatch._spatch_example.backend:divide2._should_run",
+        "additional_docs": "This is a test backend."
+    }
+}

--- a/spatch/_spatch_example/library.py
+++ b/spatch/_spatch_example/library.py
@@ -1,7 +1,10 @@
 
 from spatch.backend_system import BackendSystem
 
-backend_system = BackendSystem("_spatch_example_backends")
+backend_system = BackendSystem(
+    "_spatch_example_backends",
+    default_primary_types=["builtins:int"]
+)
 
 
 @backend_system.dispatchable(["x", "y"])

--- a/spatch/_spatch_example/library.py
+++ b/spatch/_spatch_example/library.py
@@ -1,0 +1,17 @@
+
+from spatch.backend_system import BackendSystem
+
+backend_system = BackendSystem("_spatch_example_backends")
+
+
+@backend_system.dispatchable(["x", "y"])
+def divide(x, y):
+    """Divide integers, other types may be supported via backends"""
+    if not isinstance(x, int) or not isinstance(y, int):
+        raise TypeError("x must be an integer")
+    return x // y
+
+
+
+with backend_system.backends("numpy_gpu"):
+    divide(1, 2)

--- a/spatch/_spatch_example/library.py
+++ b/spatch/_spatch_example/library.py
@@ -1,13 +1,15 @@
 
 from spatch.backend_system import BackendSystem
 
-backend_system = BackendSystem(
+_backend_system = BackendSystem(
     "_spatch_example_backends",
     default_primary_types=["builtins:int"]
 )
 
 
-@backend_system.dispatchable(["x", "y"])
+backend = _backend_system.prioritize
+
+@_backend_system.dispatchable(["x", "y"])
 def divide(x, y):
     """Divide integers, other types may be supported via backends"""
     if not isinstance(x, int) or not isinstance(y, int):

--- a/spatch/_spatch_example/library.py
+++ b/spatch/_spatch_example/library.py
@@ -10,8 +10,3 @@ def divide(x, y):
     if not isinstance(x, int) or not isinstance(y, int):
         raise TypeError("x must be an integer")
     return x // y
-
-
-
-with backend_system.backends("numpy_gpu"):
-    divide(1, 2)

--- a/spatch/backend_system.py
+++ b/spatch/backend_system.py
@@ -1,4 +1,5 @@
 import functools
+from types import MethodType
 
 
 def get_identifier(obj):
@@ -135,9 +136,10 @@ class Dispatchable:
         # Just dedent, so it makes sense to append (should be fine):
         self.__doc__ = textwrap.dedent(self.__doc__) + new_doc
 
-    def __get__(self, ):
-        raise NotImplementedError(
-            "Need to implement this eventually to act like functions.")
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return MethodType(self, obj)
 
     @property
     def _backends(self):

--- a/spatch/backend_system.py
+++ b/spatch/backend_system.py
@@ -1,0 +1,190 @@
+import functools
+
+
+def get_identifier(obj):
+    """Helper to get any objects identifier.  Is there an exiting short-hand?
+    """
+    return f"{obj.__module__}:{obj.__qualname__}"
+
+
+def from_identifier(ident):
+    module, qualname = ident.split(":")
+    obj = importlib.import_module(module)
+    for name in qualname.split("."):
+        obj = getattr(obj, name)
+
+    return obj
+
+
+class Backend:
+    @classmethod
+    def from_info_dict(cls, info_dict):
+        self = cls()
+        self.name = info_dict["name"]
+        self.symbol_mapping = info_dict["symbol_mapping"]
+
+        return cls(info_dict["name"], info_dict["symbol_mapping"])
+
+
+class BackendSystem:
+    def __init__(self, group):
+        # TODO: Should we use group and name, or is group enough?
+        # TODO: We could define types of the fallback here, or known "scalar"
+        #       (i.e. unimportant types).
+        #       In a sense, the fallback should maybe itself just be a normal
+        #       backend, except we always try it if all else fails...
+        self.backends = {}
+
+        eps = importlib_metadata.entry_points(group=group)
+        for ep in eps:
+            self.backend_from_dict(ep.load())
+
+        print(self.backends)
+
+    def backend_from_dict(self, info_dict):
+        new_backend = Backend.from_info_dict(info_dict)
+        if new_backend.name in self.backends:
+            warnings.warn(
+                UserWarning,
+                f"Backend of name '{new_backend.name}' already exists. Ignoring second!")
+            return
+        self.backends[new_backend.name] = new_backend
+
+    def dispatchable(self, *relevant_args, module=None):
+        """
+        Decorate a Python function with information on how to extract
+        the "relevant" arguments, i.e. arguments we wish to dispatch for.
+        Parameters
+        ----------
+        *relevant_args : The names of parameters to extract (we use inspect to
+                map these correctly).
+        """
+        def wrap_callable(func):
+            # Overwrite original module (we use it later, could also pass it)
+            if module is not None:
+                func.__module__ = module
+
+            disp = Dispatchable(self, func, relevant_args)
+            functools.update_wrapper(disp, func)
+
+            return disp
+
+        return wrap_callable
+
+
+# TODO: Make it a nicer singleton
+NotFound = object()
+
+
+class Implementation:
+    __slots__ = ("backend", "should_run_symbol", "should_run", "function_symbol", "function")
+
+    def __init__(self, backend, function_symbol, should_run_symbol=None):
+        """The implementation of a function, internal information?
+        """
+        self.backend = backend
+
+        self.should_run_symbol = should_run_symbol
+        if should_run_symbol is None:
+            self.should_run = None
+        else:
+            self.should_run = NotFound
+
+        self.function = NotFound
+        self.function_symbol = function_symbol
+
+
+class Dispatchable:
+    """Dispatchable function object
+
+    TODO: We may want to return a function just to be nice (not having a func was
+    OK in NumPy for example, but has a few little stumbling blocks)
+    """
+    def __init__(self, backend_system, func, relevant_args, ident=None):
+        self._backend_system = backend_system
+        self._default_func = func
+        self._relevant_args = relevant_args
+        self._ident = ident if ident is not None else get_identifier(func)
+
+        if isinstance(relevant_args, str):
+            relevant_args = {relevant_args: 0}
+        elif isinstance(relevant_args, list | tuple):
+            relevant_args = {val: i for i, val in enumerate(relevant_args)}
+        self._relevant_args = relevant_args
+
+        new_doc = []
+        for backend in backend_system.backends.values():
+            info = backend.symbol_mapping.get(ident, None)
+
+            if info is None:
+                continue  # not implemented by backend
+
+            self._implementations.append(
+                Implementation(backend, info["impl_symbol"], info.get("should_run", None))
+            )
+
+            new_blurb = info.get("additional_docs", "No backend documentation available.")
+            new_doc.append(f"backend.name :\n" + textwrap.indent(new_blurb, "    "))
+
+        if not new_doc:
+            new_doc = ["No backends found for this function."]
+
+        new_doc = "\n\n".join(new_doc)
+        new_doc = "\n\nBackends\n--------\n" + new_doc
+
+        # Just dedent, so it makes sense to append (should be fine):
+        self.__doc__ = textwrap.dedent(self.__doc__) + new_doc
+
+    def __get__(self, ):
+        raise NotImplementedError(
+            "Need to implement this eventually to act like functions.")
+
+    @property
+    def _backends(self):
+        # Extract the backends:
+        return [impl.backend for impl in self._implementations]
+
+    def _get_relevant_types(self, *args, **kwargs):
+        return frozenset(
+            type(val) for name, pos in self._relevant_args.items()
+            if (val := args[pos] if pos < len(args) else kwargs.get(name)) is not None
+        )
+
+    def __call__(self, *args, **kwargs):
+        relevant_types = self._get_relevant_types(*args, **kwargs)
+
+        matching_backends = [
+            impl for impl in self._implementations if impl.backend.matches(relevant_types)
+        ]
+    
+        if len(matching_backends) == 0:
+            return self._default_func(*args, **kwargs)
+        elif len(matching_backends) == 1:
+            impl = matching_backends[0]
+        else:
+            # Try to figure out which backend "beats" the others
+            # TODO: We can add a form of caching here, although user settings
+            # can mean we have to invalidate the cache.
+            # (If we had a clear priority from the user, we can start with that!)
+            for backend in matching_backends:
+                for other in matching_backends:
+                    if backend == other:
+                        continue
+
+                    if not backend.knows_other(backend.name):
+                        break
+                else:
+                    # This backend knew all others, so it wins
+                    impl = backend
+                    break
+
+        if impl.should_run is NotFound:
+            impl.should_run = from_identifier(impl.should_run_symbol)
+
+        if impl.should_run is None or impl.should_run(*args, **kwargs):
+            if impl.function is None:
+                impl.function = from_identifier(impl.function_symbol)
+
+            return impl.function(*args, **kwargs)
+
+        return self._default_func(*args, **kwargs)

--- a/spatch/backend_system.py
+++ b/spatch/backend_system.py
@@ -142,14 +142,16 @@ class BackendSystem:
             return
         self.backends[new_backend.name] = new_backend
 
-    def dispatchable(self, relevant_args, module=None):
+    def dispatchable(self, relevant_args=None, module=None):
         """
         Decorate a Python function with information on how to extract
         the "relevant" arguments, i.e. arguments we wish to dispatch for.
         Parameters
         ----------
-        *relevant_args : The names of parameters to extract (we use inspect to
-                map these correctly).
+        relevant_args : str, list, tuple, or None
+            The names of parameters to extract (we use inspect to
+            map these correctly).
+            If ``None`` all parameters will be considered relevant.
         """
         def wrap_callable(func):
             # Overwrite original module (we use it later, could also pass it)
@@ -276,10 +278,13 @@ class Dispatchable:
         return [impl.backend for impl in self._implementations]
 
     def _get_relevant_types(self, *args, **kwargs):
-        relevant_types = [
-            type(val) for name, pos in self._relevant_args.items()
-            if (val := args[pos] if pos < len(args) else kwargs.get(name)) is not None
-        ]
+        if self._relevant_args is None:
+            relevant_type = list(args) + [k for k in kwargs]
+        else:
+            relevant_types = [
+                type(val) for name, pos in self._relevant_args.items()
+                if (val := args[pos] if pos < len(args) else kwargs.get(name)) is not None
+            ]
         return self._backend_system.get_known_unique_types(relevant_types)
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
More details will follow, but a few guiding principles:
* Stick to strings and exact type matching (for a first thing), this:
  - ensures we don't accidentally do expensive imports
  - keeps things lean, fast precise (fast may happen in the future with caching!)
* Have tooling to build the backend
* Have tooling to mark functions as dispatchable conveniently
* Use entry-points: we always know all backends that exist.
* Implements a `backend("some_backend")` decorator to solve two things:
  - Users can prioritize a backend they want
  - There can be some backends where prioritizing is effectively _activating_.  This could then do unsafe things like generally use/return cupy arrays with skimage.
* We are planning more things, such as:
  - `func.invoke(types)` or `func.invoke_backend("backend")` for very precise dispatching.
  - It may be cool to have a way to get `skimage_cupy = ...` to always dispatch within that namespace.
* Tools for testing, more doc-string ammending, ...
* Tools for tracking which backend is used, etc. (maybe even inserting traceback steps or so).

And probably many more things.  We have to eventually write some more docs.

**For now this is a draft/PoC, however, it should have all basic functionality already needed to try it out in practice**