### PR TITLE
CI: Comment out doc deployment as permissions are missing for now

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -52,20 +52,21 @@ jobs:
         with:
           path: docs/build/html
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: inputs.deploy
-
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - uses: actions/deploy-pages@v4
-        if: inputs.deploy
+  # Comment out deploy job for now due to missing permissions.
+  # deploy:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: inputs.deploy
+  #
+  #   permissions:
+  #     pages: write      # to deploy to Pages
+  #     id-token: write   # to verify the deployment originates from an appropriate source
+  #
+  #   # Deploy to the github-pages environment
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+  #
+  #   steps:
+  #     - uses: actions/deploy-pages@v4
+  #       if: inputs.deploy


### PR DESCRIPTION
Not sure we want to deploy docs to github pages at all, it was just one very simple initial pattern to use.

But, it doesn't work right now due to missing permissions, so just comment out the deploy step (and hopefully the rest will then all run).