### PR TITLE
ENH,MAINT: Rename "relevant" to "dispatch" args and expose in context

### DIFF
--- a/src/spatch/testing.py
+++ b/src/spatch/testing.py
@@ -1,0 +1,39 @@
+from spatch.utils import get_identifier
+
+class _FuncGetter:
+    def __init__(self, get):
+        self.get = get
+
+
+class BackendDummy:
+    """Helper to construct a minimal "backend" for testing.
+
+    Forwards any lookup to the class.  Documentation are used from
+    the function which must match in the name.
+    """
+    def __init__(self):
+        self.functions = _FuncGetter(self.get_function)
+
+    @classmethod
+    def get_function(cls, name, default=None):
+        # Simply ignore the module for testing purposes.
+        _, name = name.split(":")
+
+        # Not get_identifier because it would find the super-class name.
+        res = {"function": f"{cls.__module__}:{cls.__name__}.{name}" }
+        if hasattr(cls, "uses_context"):
+            res["uses_context"] = cls.uses_context
+        if hasattr(cls, "should_run"):
+            res["should_run"] = get_identifier(cls.should_run)
+
+        func = getattr(cls, name)
+        if func.__doc__ is not None:
+            res["additional_docs"] = func.__doc__
+
+        return res
+
+    @classmethod
+    def dummy_func(cls, *args, **kwargs):
+        # Always define a small function that mainly forwards.
+        return cls.name, args, kwargs
+

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,51 @@
+import pytest
+
+from spatch.backend_system import BackendSystem
+from spatch.testing import BackendDummy
+
+
+class FloatWithContext(BackendDummy):
+    name = "FloatWithContext"
+    primary_types = ("~builtins:float",)
+    secondary_types = ("builtins:int",)
+    uses_context = True
+    requires_opt_in = False
+
+
+def test_context_basic():
+    bs = BackendSystem(
+        None,
+        environ_prefix="SPATCH_TEST",
+        default_primary_types=("builtin:int",),
+        backends=[FloatWithContext()]
+    )
+
+    # Add a dummy dispatchable function that dispatches on all arguments.
+    @bs.dispatchable(None, module="<test>", qualname="dummy_func")
+    def dummy_func(*args, **kwargs):
+        return "fallback", args, kwargs
+
+    _, (ctx, *args), kwargs = dummy_func(1, 1.)
+    assert ctx.name == "FloatWithContext"
+    assert set(ctx.types) == {int, float}
+    assert ctx.dispatch_args == (1, 1.)
+    assert not ctx.prioritized
+
+    class float_subclass(float):
+        pass
+
+    with bs.backend_opts(prioritize=("FloatWithContext",)):
+        _, (ctx, *args), kwargs = dummy_func(float_subclass(1.))
+        assert ctx.name == "FloatWithContext"
+        assert set(ctx.types) == {float_subclass}
+        assert ctx.dispatch_args == (float_subclass(1.),)
+        assert ctx.prioritized
+
+    with bs.backend_opts(type=float):
+        # No argument, works if explicitly prioritized...
+        _, (ctx, *args), kwargs = dummy_func()
+        assert ctx.name == "FloatWithContext"
+        assert set(ctx.types) == {float}
+        assert ctx.dispatch_args == ()
+        assert not ctx.prioritized  # not prioritized "just" type enforced
+

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,44 +1,7 @@
 import pytest
 
 from spatch.backend_system import BackendSystem
-from spatch.utils import get_identifier
-
-class FuncGetter:
-    def __init__(self, get):
-        self.get = get
-
-
-class BackendDummy:
-    """Helper to construct a minimal "backend" for testing.
-
-    Forwards any lookup to the class.  Documentation are used from
-    the function which must match in the name.
-    """
-    def __init__(self):
-        self.functions = FuncGetter(self.get_function)
-
-    @classmethod
-    def get_function(cls, name, default=None):
-        # Simply ignore the module for testing purposes.
-        _, name = name.split(":")
-
-        # Not get_identifier because it would find the super-class name.
-        res = {"function": f"{cls.__module__}:{cls.__name__}.{name}" }
-        if hasattr(cls, "uses_context"):
-            res["uses_context"] = cls.uses_context
-        if hasattr(cls, "should_run"):
-            res["should_run"] = get_identifier(cls.should_run)
-
-        func = getattr(cls, name)
-        if func.__doc__ is not None:
-            res["additional_docs"] = func.__doc__
-
-        return res
-
-    @classmethod
-    def dummy_func(cls, *args, **kwargs):
-        # Always define a small function that mainly forwards.
-        return cls.name, args, kwargs
+from spatch.testing import BackendDummy
 
 
 class IntB(BackendDummy):


### PR DESCRIPTION
This is useful for generic wrappers.  I still wan to hold back to do all the work for them, but the information is rather readily available, so I think we can pass it on.

NumPy uses "relevant args" naming for the arguments we dispatch on, I decided to rename it to "dispatch" instead.
(Also changed to pass a tuple of types, because I think that is more future proof.  We expect few types, a set isn't useful e.g. if done in C.)

---

cleaned up the tests slightly, to add a basic one for the context.