### PR TITLE
Use hatch-vcs for dynamic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spatch"
 authors = [
     {name = "Scientific Python Developers"},
 ]
-version = "0.0.0"
+dynamic = ["version"]
 description = "Coming soon"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -33,6 +33,9 @@ docs = [
   "pydata-sphinx-theme",
   "myst-parser",
 ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"

--- a/src/spatch/__init__.py
+++ b/src/spatch/__init__.py
@@ -1,1 +1,18 @@
+from importlib.metadata import version
 from .utils import from_identifier, get_identifier
+
+try:
+    __version__ = version("spatch")
+except ModuleNotFoundError:
+    import warnings
+
+    warnings.warn(
+        "No version metadata found for spatch, so `spatch.__version__` will be "
+        "set to None. This may mean that spatch was incorrectly installed or "
+        "not installed at all. For local development, consider doing an "
+        "editable install via `python -m pip install -e .` from within the "
+        "root `spatch/` repository folder."
+    )
+    __version__ = None
+    del warnings
+del version

--- a/src/spatch/__init__.py
+++ b/src/spatch/__init__.py
@@ -1,18 +1,3 @@
-from importlib.metadata import version
-from .utils import from_identifier, get_identifier
+from .utils import from_identifier, get_identifier, get_project_version
 
-try:
-    __version__ = version("spatch")
-except ModuleNotFoundError:
-    import warnings
-
-    warnings.warn(
-        "No version metadata found for spatch, so `spatch.__version__` will be "
-        "set to None. This may mean that spatch was incorrectly installed or "
-        "not installed at all. For local development, consider doing an "
-        "editable install via `python -m pip install -e .` from within the "
-        "root `spatch/` repository folder."
-    )
-    __version__ = None
-    del warnings
-del version
+__version__ = get_project_version("spatch")


### PR DESCRIPTION
This minimally adds dynamic package version using hatch-vcs, which I saw was already included in `[build-system]` of pyproject.toml. The dev version will be silly until we tag a release.

I also warn if the package may not be installed properly. I like doing this, and I don't know if there's a better, builtin way to do this. When entry-points are involved, it's important that packages be installed so that entry-points may be found.

I'm tool-agnostic and don't have a strong opinion about hatch or others.