### PR TITLE
Attempt to fix pre-commit github action on main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+# Alternatively, consider using https://pre-commit.ci/
 name: pre-commit checks
 
 on:
@@ -18,3 +19,5 @@ jobs:
         with:
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: "no-commit-to-branch"


### PR DESCRIPTION
We should skip `no-commit-to-branch` in ci on main branch.

We could also use https://pre-commit.ci/ instead of this github action, which is already configured to skip this action.