### PR TITLE
Add `verify-entrypoints` command to verify entrypoints

### DIFF
--- a/src/spatch/__main__.py
+++ b/src/spatch/__main__.py
@@ -1,6 +1,6 @@
 import argparse
 
-from .backend_utils import update_entrypoint
+from .backend_utils import update_entrypoint, verify_entrypoint
 
 
 def main():
@@ -13,14 +13,32 @@ def main():
     update_entrypoint_cmd.add_argument(
         "paths", type=str, nargs="+", help="paths to the entrypoint toml files to update"
     )
+    update_entrypoint_cmd.add_argument(
+        "--verify",
+        action="store_true",
+        help="verify updated entrypoints",
+    )
+
+    verify_entrypoint_cmd = subparsers.add_parser(
+        "verify-entrypoints", help="verify the entrypoint toml file"
+    )
+    verify_entrypoint_cmd.add_argument(
+        "paths", type=str, nargs="+", help="paths to the entrypoint toml files to verify"
+    )
 
     args = parser.parse_args()
-
+    verify = False
     if args.subcommand == "update-entrypoints":
         for path in args.paths:
             update_entrypoint(path)
+        verify = args.verify
+    elif args.subcommand == "verify-entrypoints":
+        verify = True
     else:
         raise RuntimeError("unreachable: subcommand not known.")
+    if verify:
+        for path in args.paths:
+            verify_entrypoint(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a quick and dirty way to verify the items in entrypoints. `verify-entrypoints` command checks existing files, and `update-entrypoints --verify` is a convenient way to verify the entry points that are updated (maybe this should only check the autogenerated functions?).

Not super polished or the best messages, but I think this code should be maintainable as we make changes and hopefully clear enough to be added to. I'd also like to add some tests.